### PR TITLE
Update Box.sol

### DIFF
--- a/src/Box.sol
+++ b/src/Box.sol
@@ -10,6 +10,9 @@ contract Box is Ownable {
     // Emitted when the stored value changes
     event ValueChanged(uint256 newValue);
 
+    // initial owner of this smart contract is the deployer of this smart contract
+    constructor() Ownable(msg.sender) {}   
+
     // Stores a new value in the contract
     function store(uint256 newValue) public onlyOwner {
         value = newValue;


### PR DESCRIPTION
Resolve Error with solidity v0.8.23: `No arguments passed to the base constructor. Specify the arguments or mark "Box" as abstract.`

The `Ownable` contract requires an argument `initialOwner` which is not optional. This PR adds that.