### PR TITLE
Remove hardcode values related to voting governance

### DIFF
--- a/src/MyGovernor.sol
+++ b/src/MyGovernor.sol
@@ -21,11 +21,11 @@ contract MyGovernor is
     GovernorVotesQuorumFraction,
     GovernorTimelockControl
 {
-    constructor(IVotes _token, TimelockController _timelock)
+    constructor(IVotes _token, TimelockController _timelock, uint48 _initialVotingDelay, uint32 _votingPeriod, uint256 _votingThreshold,uint256 _quorumPercentage)
         Governor("MyGovernor")
-        GovernorSettings(1, /* 1 block */ 50400, /* 1 week */ 0)
+        GovernorSettings(_initialVotingDelay, _votingPeriod, _votingThreshold)
         GovernorVotes(_token)
-        GovernorVotesQuorumFraction(4)
+        GovernorVotesQuorumFraction(_quorumPercentage)
         GovernorTimelockControl(_timelock)
     {}
 

--- a/test/MyGovernorTest.t.sol
+++ b/test/MyGovernorTest.t.sol
@@ -15,8 +15,9 @@ contract MyGovernorTest is Test {
 
     uint256 public constant MIN_DELAY = 3600; // 1 hour - after a vote passes, you have 1 hour before you can enact
     uint256 public constant QUORUM_PERCENTAGE = 4; // Need 4% of voters to pass
-    uint256 public constant VOTING_PERIOD = 50400; // This is how long voting lasts
-    uint256 public constant VOTING_DELAY = 1; // How many blocks till a proposal vote becomes active
+    uint32 public constant VOTING_PERIOD = 50400; // This is how long voting lasts
+    uint48 public constant VOTING_DELAY = 1; // How many blocks till a proposal vote becomes active
+    uint256 public constant VOTING_THRESHOLD = 0;
 
     address[] proposers;
     address[] executors;
@@ -34,7 +35,7 @@ contract MyGovernorTest is Test {
         vm.prank(VOTER);
         token.delegate(VOTER);
         timelock = new TimeLock(MIN_DELAY, proposers, executors);
-        governor = new MyGovernor(token, timelock);
+        governor = new MyGovernor(token, timelock,VOTING_DELAY,VOTING_PERIOD,VOTING_THRESHOLD,QUORUM_PERCENTAGE);
         bytes32 proposerRole = timelock.PROPOSER_ROLE();
         bytes32 executorRole = timelock.EXECUTOR_ROLE();
         bytes32 adminRole = timelock.TIMELOCK_ADMIN_ROLE();


### PR DESCRIPTION
### Context
The GovernorSettings contract previously used hardcoded values for the following governance parameters:

- **votingDelay:** Delay before voting on a proposal starts (default: 1 block).
- **votingPeriod:** Duration for which voting remains open (default: 1 week).
- **proposalThreshold:** Minimum number of votes required to create a proposal (default: 0).

These values were directly embedded in the **Governor** contract and were also used in the **GovernorTest** contract for testing purposes. It's a bit confusion since we introduced the magic numbers. Removing magic numbers might help us to understand it in a better way.

### Changes Introduced
This PR refactors the Governor contract to remove hardcoded governance parameter values and instead allows them to be passed as arguments during deployment.

The constructor has been updated to:
`constructor(
    IVotes _token,
    TimelockController _timelock,
    uint48 _initialVotingDelay,
    uint32 _votingPeriod,
    uint256 _votingThreshold,
    uint256 _quorumPercentage
)
`

### Benifits

- Deployers can customize governance settings to suit their specific requirements without modifying the contract code.
- The updated design enables testing with different parameter values, improving the robustness of the contract.

